### PR TITLE
fix: P0-critical security hardening (#29, #30)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,16 @@ jobs:
         working-directory: programs/allocator
         env:
           RUSTFLAGS: "-D warnings"
+      - name: Build with devnet features
+        run: cargo build --features devnet
+        working-directory: programs/allocator
+        env:
+          RUSTFLAGS: "-D warnings"
+      - name: Test with devnet features
+        run: cargo test --features devnet
+        working-directory: programs/allocator
+        env:
+          RUSTFLAGS: "-D warnings"
       - name: Audit Rust dependencies
         run: |
           cargo install cargo-audit --quiet

--- a/docs/superpowers/plans/2026-04-10-critical-keeper-bugs.md
+++ b/docs/superpowers/plans/2026-04-10-critical-keeper-bugs.md
@@ -1,0 +1,624 @@
+# Critical Keeper Bugs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix 3 critical bugs that make the keeper's on-chain rebalance submissions non-functional (#1, #2, #3).
+
+**Architecture:** Create a chain state utility for on-chain reads, wire real addresses/counter into submitRebalance, and add live Marginfi rate fetching. One branch `fix/critical-keeper-bugs` in nanuqfi-keeper.
+
+**Tech Stack:** TypeScript, @solana/web3.js, @coral-xyz/anchor, Vitest
+
+---
+
+## File Structure
+
+```
+src/
+  chain/
+    state.ts          # NEW — fetch on-chain account state (RiskVault, Treasury, token balances)
+    rebalance.ts      # EXISTING — add getAssociatedTokenAddress helper
+  rates/
+    marginfi.ts       # NEW — live Marginfi rate fetching via DeFi Llama
+  keeper.ts           # MODIFY — wire real chain state + live rates
+  __tests__/
+    chain-state.test.ts     # NEW — tests for chain state fetcher
+    marginfi-rate.test.ts   # NEW — tests for rate fetching
+```
+
+---
+
+## Task 1: Create chain state utility
+
+**Files:**
+- Create: `src/chain/state.ts`
+- Create: `src/__tests__/chain-state.test.ts`
+- Modify: `src/chain/rebalance.ts` (add ATA helper)
+
+This task creates the shared infrastructure that bugs #1 and #2 both need: reading on-chain account data to get real addresses and counters.
+
+- [ ] **Step 1: Create branch**
+
+```bash
+cd ~/local-dev/nanuqfi-keeper
+git checkout -b fix/critical-keeper-bugs
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `src/__tests__/chain-state.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Connection, PublicKey } from '@solana/web3.js'
+
+vi.mock('@solana/web3.js', async () => {
+  const actual = await vi.importActual<typeof import('@solana/web3.js')>('@solana/web3.js')
+  return {
+    ...actual,
+    Connection: vi.fn(),
+  }
+})
+
+import { fetchRebalanceChainState } from '../chain/state'
+
+describe('fetchRebalanceChainState', () => {
+  let mockConnection: any
+
+  beforeEach(() => {
+    mockConnection = {
+      getAccountInfo: vi.fn(),
+      getTokenAccountBalance: vi.fn(),
+    }
+    vi.mocked(Connection).mockImplementation(() => mockConnection)
+  })
+
+  it('returns rebalance counter from RiskVault account', async () => {
+    // Build mock RiskVault account data
+    // Offset for rebalance_counter: 8 (disc) + 1 + 32 + 1 + 32 + 32 + 8 + 8 + 8 + 8 + 8 + 8 = 156
+    const data = Buffer.alloc(256)
+    data.writeUInt32LE(42, 8 + 1 + 32 + 1 + 32 + 32 + 8 + 8 + 8 + 8 + 8 + 8) // counter = 42
+
+    // Mock Treasury account data
+    // Offset for usdc_token_account: 8 (disc) + 1 + 32 = 41
+    const treasuryData = Buffer.alloc(128)
+    const fakeTreasuryUsdc = PublicKey.unique()
+    fakeTreasuryUsdc.toBuffer().copy(treasuryData, 8 + 1 + 32)
+
+    mockConnection.getAccountInfo
+      .mockResolvedValueOnce({ data }) // RiskVault
+      .mockResolvedValueOnce({ data: treasuryData }) // Treasury
+
+    mockConnection.getTokenAccountBalance.mockResolvedValueOnce({
+      value: { amount: '5000000', decimals: 6 },
+    })
+
+    const result = await fetchRebalanceChainState('https://rpc.test', 'moderate')
+
+    expect(result.rebalanceCounter).toBe(42)
+    expect(result.treasuryUsdcAddress.equals(fakeTreasuryUsdc)).toBe(true)
+    expect(result.equitySnapshot).toBe(5000000n)
+  })
+
+  it('throws when RiskVault account not found', async () => {
+    mockConnection.getAccountInfo.mockResolvedValueOnce(null)
+
+    await expect(
+      fetchRebalanceChainState('https://rpc.test', 'moderate'),
+    ).rejects.toThrow('RiskVault account not found')
+  })
+})
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+```bash
+pnpm vitest run src/__tests__/chain-state.test.ts
+```
+
+Expected: FAIL — `chain/state.ts` does not exist.
+
+- [ ] **Step 4: Add ATA derivation helper to rebalance.ts**
+
+In `src/chain/rebalance.ts`, add these constants and helper at the top (after existing imports):
+
+```typescript
+const SPL_TOKEN_PROGRAM = new PublicKey('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA')
+const ASSOCIATED_TOKEN_PROGRAM = new PublicKey('ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL')
+
+export function getAssociatedTokenAddress(mint: PublicKey, owner: PublicKey): PublicKey {
+  const [ata] = PublicKey.findProgramAddressSync(
+    [owner.toBuffer(), SPL_TOKEN_PROGRAM.toBuffer(), mint.toBuffer()],
+    ASSOCIATED_TOKEN_PROGRAM,
+  )
+  return ata
+}
+```
+
+- [ ] **Step 5: Create chain state fetcher**
+
+Create `src/chain/state.ts`:
+
+```typescript
+import { Connection, PublicKey } from '@solana/web3.js'
+import {
+  deriveAllocatorPda,
+  deriveRiskVaultPda,
+  deriveTreasuryPda,
+  getAssociatedTokenAddress,
+  riskLevelToIndex,
+  USDC_MINT,
+} from './rebalance'
+
+// ─── Byte offsets for Anchor account deserialization ────────────────────
+// All offsets include the 8-byte Anchor discriminator prefix.
+
+// RiskVault: disc(8) + version(1) + allocator(32) + risk_level(1) +
+//            protocol_vault(32) + share_mint(32) + total_shares(8) +
+//            total_assets(8) + peak_equity(8) + current_equity(8) +
+//            equity_24h_ago(8) + last_rebalance_slot(8) = 156
+const RISK_VAULT_REBALANCE_COUNTER_OFFSET = 8 + 1 + 32 + 1 + 32 + 32 + 8 + 8 + 8 + 8 + 8 + 8
+
+// Treasury: disc(8) + version(1) + allocator(32) = 41
+const TREASURY_USDC_ACCOUNT_OFFSET = 8 + 1 + 32
+
+// ─── Types ──────────────────────────────────────────────────────────────
+
+export interface RebalanceChainState {
+  rebalanceCounter: number
+  vaultUsdcAddress: PublicKey
+  treasuryUsdcAddress: PublicKey
+  equitySnapshot: bigint
+}
+
+// ─── Fetcher ────────────────────────────────────────────────────────────
+
+export async function fetchRebalanceChainState(
+  rpcUrl: string,
+  riskLevel: string,
+): Promise<RebalanceChainState> {
+  const connection = new Connection(rpcUrl, 'confirmed')
+  const riskIdx = riskLevelToIndex(riskLevel)
+
+  const [allocatorPda] = deriveAllocatorPda()
+  const [riskVaultPda] = deriveRiskVaultPda(allocatorPda, riskIdx)
+  const [treasuryPda] = deriveTreasuryPda()
+
+  // Fetch RiskVault + Treasury in parallel
+  const [riskVaultInfo, treasuryInfo] = await Promise.all([
+    connection.getAccountInfo(riskVaultPda),
+    connection.getAccountInfo(treasuryPda),
+  ])
+
+  if (!riskVaultInfo?.data) {
+    throw new Error(`RiskVault account not found for ${riskLevel} (PDA: ${riskVaultPda.toBase58()})`)
+  }
+  if (!treasuryInfo?.data) {
+    throw new Error(`Treasury account not found (PDA: ${treasuryPda.toBase58()})`)
+  }
+
+  // Read rebalance_counter (u32 LE) from RiskVault
+  const rebalanceCounter = riskVaultInfo.data.readUInt32LE(RISK_VAULT_REBALANCE_COUNTER_OFFSET)
+
+  // Read usdc_token_account (Pubkey, 32 bytes) from Treasury
+  const treasuryUsdcAddress = new PublicKey(
+    treasuryInfo.data.subarray(TREASURY_USDC_ACCOUNT_OFFSET, TREASURY_USDC_ACCOUNT_OFFSET + 32),
+  )
+
+  // Derive vault USDC ATA (allocator PDA owns it)
+  const vaultUsdcAddress = getAssociatedTokenAddress(USDC_MINT, allocatorPda)
+
+  // Fetch vault USDC balance for equity snapshot
+  const balance = await connection.getTokenAccountBalance(vaultUsdcAddress)
+  const equitySnapshot = BigInt(balance.value.amount)
+
+  return { rebalanceCounter, vaultUsdcAddress, treasuryUsdcAddress, equitySnapshot }
+}
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+```bash
+pnpm vitest run src/__tests__/chain-state.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/chain/state.ts src/chain/rebalance.ts src/__tests__/chain-state.test.ts
+git commit -m "feat(chain): add on-chain state fetcher for rebalance params
+
+Reads RiskVault rebalance_counter, Treasury USDC address, and vault
+USDC balance from on-chain accounts. Used by submitRebalance to pass
+real addresses instead of placeholders."
+```
+
+---
+
+## Task 2: Wire real chain state into submitRebalance (#1, #2)
+
+**Files:**
+- Modify: `src/keeper.ts` (runCycle submitRebalance call)
+- Modify: `src/__tests__/keeper-rebalance.test.ts` (update mocks)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/__tests__/keeper-rebalance.test.ts`:
+
+```typescript
+// Add mock at top of file
+vi.mock('../chain/state', () => ({
+  fetchRebalanceChainState: vi.fn(),
+}))
+
+import { fetchRebalanceChainState } from '../chain/state'
+
+const mockFetchChainState = vi.mocked(fetchRebalanceChainState)
+```
+
+Add test case:
+
+```typescript
+  it('passes real chain state to submitRebalance', async () => {
+    const fakeVaultUsdc = PublicKey.unique()
+    const fakeTreasuryUsdc = PublicKey.unique()
+
+    mockFetchChainState.mockResolvedValue({
+      rebalanceCounter: 7,
+      vaultUsdcAddress: fakeVaultUsdc,
+      treasuryUsdcAddress: fakeTreasuryUsdc,
+      equitySnapshot: 5000000n,
+    })
+
+    mockSubmitRebalance.mockResolvedValue({
+      success: true,
+      txSignature: 'real-chain-state-tx',
+    })
+
+    await keeper.runCycle()
+
+    expect(mockSubmitRebalance).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rebalanceCounter: 7,
+        equitySnapshot: 5000000n,
+        vaultUsdcAddress: fakeVaultUsdc,
+        treasuryUsdcAddress: fakeTreasuryUsdc,
+      }),
+    )
+  })
+
+  it('marks decision as failed when chain state fetch fails', async () => {
+    mockFetchChainState.mockRejectedValue(new Error('RPC timeout'))
+
+    await keeper.runCycle()
+
+    const decisions: KeeperDecision[] = keeper.decisions
+    const failed = decisions.filter((d: KeeperDecision) => d.txStatus === 'failed')
+    expect(failed.length).toBeGreaterThan(0)
+    expect(keeper.alerter.alert).toHaveBeenCalledWith(
+      expect.stringContaining('RPC timeout'),
+    )
+  })
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pnpm vitest run src/__tests__/keeper-rebalance.test.ts
+```
+
+Expected: FAIL — keeper still uses hardcoded System Program addresses.
+
+- [ ] **Step 3: Update runCycle to fetch and use real chain state**
+
+In `src/keeper.ts`, add the import at the top:
+
+```typescript
+import { fetchRebalanceChainState } from './chain/state'
+```
+
+Replace the submitRebalance block inside the `if (this.config.keeperKeypairPath && this.config.rpcUrls[0])` section. The current code has hardcoded addresses. Replace with:
+
+```typescript
+        // Submit rebalance tx to on-chain allocator (if keypair configured)
+        if (this.config.keeperKeypairPath && this.config.rpcUrls[0]) {
+          const reasoning = this.getAIInsight()?.reasoning ?? 'Algorithm-only rebalance'
+          const decision = this.decisions[this.decisions.length - 1]
+
+          if (decision) decision.txStatus = 'pending'
+
+          try {
+            // Fetch real on-chain state: counter, addresses, equity
+            const chainState = await fetchRebalanceChainState(this.config.rpcUrls[0], riskLevel)
+
+            const result = await submitRebalance({
+              rpcUrl: this.config.rpcUrls[0],
+              keypairPath: this.config.keeperKeypairPath,
+              riskLevel,
+              weights: proposal.weights,
+              reasoning,
+              rebalanceCounter: chainState.rebalanceCounter,
+              equitySnapshot: chainState.equitySnapshot,
+              vaultUsdcAddress: chainState.vaultUsdcAddress,
+              treasuryUsdcAddress: chainState.treasuryUsdcAddress,
+            })
+
+            if (result.success) {
+              if (decision) {
+                decision.txSignature = result.txSignature
+                decision.txStatus = 'confirmed'
+              }
+              this.currentWeights[riskLevel] = proposal.weights
+              console.log(`[Chain] Rebalance tx confirmed: ${result.txSignature}`)
+            } else {
+              if (decision) decision.txStatus = 'failed'
+              console.error(`[Chain] Rebalance tx failed for ${riskLevel}: ${result.error}`)
+              await this.alerter.alert(`❌ On-chain rebalance failed for ${riskLevel}: ${result.error}`)
+            }
+          } catch (err) {
+            if (decision) decision.txStatus = 'failed'
+            const msg = err instanceof Error ? err.message : String(err)
+            console.error(`[Chain] Rebalance submission error for ${riskLevel}: ${msg}`)
+            await this.alerter.alert(`❌ On-chain rebalance error for ${riskLevel}: ${msg}`)
+          }
+        } else {
+          // Algorithm-only mode — no on-chain tx, update weights directly
+          this.currentWeights[riskLevel] = proposal.weights
+        }
+```
+
+Key changes from current code:
+- `rebalanceCounter: chainState.rebalanceCounter` (was `this.decisions.length`)
+- `equitySnapshot: chainState.equitySnapshot` (was `0n`)
+- `vaultUsdcAddress: chainState.vaultUsdcAddress` (was System Program)
+- `treasuryUsdcAddress: chainState.treasuryUsdcAddress` (was System Program)
+- Removed the `await import('@solana/web3.js')` dynamic imports (no longer needed)
+
+- [ ] **Step 4: Update existing test mocks**
+
+In `src/__tests__/keeper-rebalance.test.ts`, the `beforeEach` needs to mock `fetchRebalanceChainState` with default values so existing tests don't break:
+
+```typescript
+  beforeEach(async () => {
+    vi.resetAllMocks()
+
+    // Default chain state mock — existing tests need this
+    mockFetchChainState.mockResolvedValue({
+      rebalanceCounter: 0,
+      vaultUsdcAddress: PublicKey.default,
+      treasuryUsdcAddress: PublicKey.default,
+      equitySnapshot: 1000000n,
+    })
+
+    // ... rest of existing beforeEach
+  })
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+pnpm vitest run src/__tests__/keeper-rebalance.test.ts
+```
+
+Expected: All tests pass (existing + 2 new).
+
+- [ ] **Step 6: Run full suite**
+
+```bash
+pnpm vitest run
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/keeper.ts src/__tests__/keeper-rebalance.test.ts
+git commit -m "fix: use real on-chain addresses and counter for rebalance
+
+Replaced hardcoded System Program addresses and global decision
+count with real on-chain state:
+- vaultUsdcAddress: derived ATA for allocator PDA
+- treasuryUsdcAddress: read from Treasury account
+- equitySnapshot: vault USDC token balance
+- rebalanceCounter: per-vault counter from RiskVault account
+
+Closes #1, closes #2"
+```
+
+---
+
+## Task 3: Add live Marginfi rate fetching (#3)
+
+**Files:**
+- Create: `src/rates/marginfi.ts`
+- Create: `src/__tests__/marginfi-rate.test.ts`
+- Modify: `src/keeper.ts` (fetchYieldData)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/__tests__/marginfi-rate.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+import { fetchMarginfiRate, MARGINFI_FALLBACK_RATE } from '../rates/marginfi'
+
+describe('fetchMarginfiRate', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('returns live APY from DeFi Llama', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({
+        data: [
+          { project: 'marginfi', symbol: 'USDC', chain: 'Solana', apy: 7.5, tvlUsd: 50000000 },
+          { project: 'other', symbol: 'USDC', chain: 'Solana', apy: 3.0, tvlUsd: 10000000 },
+        ],
+      }),
+    })
+
+    const rate = await fetchMarginfiRate()
+    expect(rate).toBeCloseTo(0.075, 3) // 7.5% → 0.075
+  })
+
+  it('returns fallback when API fails', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('Network error'))
+
+    const rate = await fetchMarginfiRate()
+    expect(rate).toBe(MARGINFI_FALLBACK_RATE)
+  })
+
+  it('returns fallback when pool not found', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ data: [] }),
+    })
+
+    const rate = await fetchMarginfiRate()
+    expect(rate).toBe(MARGINFI_FALLBACK_RATE)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pnpm vitest run src/__tests__/marginfi-rate.test.ts
+```
+
+Expected: FAIL — `rates/marginfi.ts` does not exist.
+
+- [ ] **Step 3: Create the rate fetcher**
+
+Create `src/rates/marginfi.ts`:
+
+```typescript
+export const MARGINFI_FALLBACK_RATE = 0.065
+
+const DEFI_LLAMA_POOLS_URL = 'https://yields.llama.fi/pools'
+const TIMEOUT_MS = 10_000
+
+/**
+ * Fetch live Marginfi USDC lending rate from DeFi Llama.
+ * Falls back to 6.5% if the API is unavailable or the pool isn't found.
+ */
+export async function fetchMarginfiRate(): Promise<number> {
+  try {
+    const res = await fetch(DEFI_LLAMA_POOLS_URL, {
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+    })
+
+    if (!res.ok) {
+      console.warn(`[Marginfi] DeFi Llama API returned ${res.status}, using fallback`)
+      return MARGINFI_FALLBACK_RATE
+    }
+
+    const data = await res.json()
+    const pool = data.data?.find(
+      (p: { project: string; symbol: string; chain: string }) =>
+        p.project === 'marginfi' &&
+        p.symbol === 'USDC' &&
+        p.chain === 'Solana',
+    )
+
+    if (!pool || typeof pool.apy !== 'number') {
+      console.warn('[Marginfi] USDC pool not found on DeFi Llama, using fallback')
+      return MARGINFI_FALLBACK_RATE
+    }
+
+    const rate = pool.apy / 100 // DeFi Llama returns percentage (e.g., 7.5 → 0.075)
+    console.log(`[Marginfi] Live rate: ${(rate * 100).toFixed(2)}%`)
+    return rate
+  } catch (err) {
+    console.warn(`[Marginfi] Rate fetch failed: ${err instanceof Error ? err.message : err}, using fallback`)
+    return MARGINFI_FALLBACK_RATE
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+pnpm vitest run src/__tests__/marginfi-rate.test.ts
+```
+
+Expected: PASS — all 3 tests green.
+
+- [ ] **Step 5: Wire into keeper's fetchYieldData**
+
+In `src/keeper.ts`, add the import:
+
+```typescript
+import { fetchMarginfiRate } from './rates/marginfi'
+```
+
+Find the `fetchYieldData()` method. Locate the hardcoded Marginfi rate line:
+
+```typescript
+// BEFORE
+marginfiLendingRate: 0.065, // Mock — Marginfi SDK has broken IDL
+
+// AFTER
+marginfiLendingRate: await fetchMarginfiRate(),
+```
+
+- [ ] **Step 6: Run full test suite**
+
+```bash
+pnpm vitest run
+```
+
+Expected: All tests pass. Existing tests that mock `fetchYieldData` won't be affected since they stub the entire method.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/rates/marginfi.ts src/__tests__/marginfi-rate.test.ts src/keeper.ts
+git commit -m "fix: fetch live Marginfi USDC lending rate from DeFi Llama
+
+Replaced hardcoded 6.5% rate with live fetch from DeFi Llama pools
+API. Falls back to 6.5% if API unavailable or pool not found.
+Follows same pattern as Kamino and Lulo rate fetchers.
+
+Closes #3"
+```
+
+---
+
+## Task 4: Push and create PR
+
+- [ ] **Step 1: Push branch**
+
+```bash
+cd ~/local-dev/nanuqfi-keeper
+git push -u origin fix/critical-keeper-bugs
+```
+
+- [ ] **Step 2: Create PR**
+
+```bash
+gh pr create --title "fix: critical keeper bugs — real addresses, counter, live rates (#1, #2, #3)" --body "## Summary
+- Fetch real on-chain addresses for vault USDC and treasury USDC instead of System Program placeholders (#1)
+- Use per-vault rebalance counter from RiskVault account instead of global decision count (#2)
+- Fetch live Marginfi USDC rate from DeFi Llama instead of hardcoded 6.5% (#3)
+
+## Changes
+- \`src/chain/state.ts\`: On-chain account reader (RiskVault counter, Treasury USDC address, vault balance)
+- \`src/chain/rebalance.ts\`: Added ATA derivation helper
+- \`src/rates/marginfi.ts\`: DeFi Llama rate fetcher with 6.5% fallback
+- \`src/keeper.ts\`: Wired real chain state + live rate into runCycle
+
+## Test plan
+- [ ] Chain state: reads counter from mock RiskVault data, throws on missing account
+- [ ] submitRebalance receives real addresses and counter (not System Program)
+- [ ] Chain state fetch failure → decision marked failed + alert sent
+- [ ] Marginfi rate: parses DeFi Llama response, falls back on error/missing pool
+- [ ] pnpm vitest run — all tests pass"
+```

--- a/docs/superpowers/plans/2026-04-10-p0-critical-fixes.md
+++ b/docs/superpowers/plans/2026-04-10-p0-critical-fixes.md
@@ -1,0 +1,1050 @@
+# P0-Critical Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix all 5 P0-critical security/correctness issues across the NanuqFi ecosystem (3 repos).
+
+**Architecture:** Three independent `fix/p0-critical-hardening` branches — one per repo. Each fix includes a verification test. Issues: #29, #30 (core), #21, #22 (app), #9 (keeper).
+
+**Tech Stack:** Rust/Anchor 0.30.1, TypeScript, Next.js 16, Vitest, @solana/web3.js
+
+---
+
+## Task 1: Fix #29 — Remove devnet from default Cargo features
+
+**Repo:** `nanuqfi/nanuqfi` (`~/local-dev/nanuqfi/`)
+
+**Files:**
+- Modify: `programs/allocator/Cargo.toml` (features section)
+
+- [ ] **Step 1: Create branch**
+
+```bash
+cd ~/local-dev/nanuqfi
+git checkout -b fix/p0-critical-hardening
+```
+
+- [ ] **Step 2: Change default features**
+
+In `programs/allocator/Cargo.toml`, change:
+
+```toml
+# BEFORE
+default = ["devnet"]
+
+# AFTER
+default = []
+```
+
+- [ ] **Step 3: Verify mainnet build compiles without devnet instructions**
+
+```bash
+cd ~/local-dev/nanuqfi
+cargo build-sbf --manifest-path programs/allocator/Cargo.toml 2>&1 | head -5
+```
+
+Expected: Build succeeds. The `admin_reset_vault`, `admin_set_tvl`, `admin_set_rebalance_counter` instructions are excluded.
+
+- [ ] **Step 4: Verify devnet build still compiles with devnet feature flag**
+
+```bash
+cd ~/local-dev/nanuqfi
+cargo build-sbf --manifest-path programs/allocator/Cargo.toml --features devnet 2>&1 | head -5
+```
+
+Expected: Build succeeds with all instructions including devnet admin ones.
+
+- [ ] **Step 5: Verify Rust tests pass with devnet feature**
+
+```bash
+cd ~/local-dev/nanuqfi
+cargo test --manifest-path programs/allocator/Cargo.toml --features devnet
+```
+
+Expected: All 98 Rust tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd ~/local-dev/nanuqfi
+git add programs/allocator/Cargo.toml
+git commit -m "fix(program): remove devnet from default Cargo features
+
+Devnet admin instructions (admin_reset_vault, admin_set_tvl,
+admin_set_rebalance_counter) were compiling into mainnet builds.
+Now require explicit --features devnet flag.
+
+Closes #29"
+```
+
+---
+
+## Task 2: Fix #30 — Add token mint/authority constraints
+
+**Repo:** `nanuqfi/nanuqfi` (`~/local-dev/nanuqfi/`)
+
+**Files:**
+- Modify: `programs/allocator/src/lib.rs` (Deposit, Withdraw, AllocateToProtocol, RecallFromProtocol context structs)
+- Test: existing `cargo test` suite
+
+The `usdc_mint` and `share_mint` accounts are already present in each context. We just need to add `token::mint` and `token::authority` constraints to the unconstrained token accounts.
+
+- [ ] **Step 1: Add constraints to Deposit context**
+
+In `programs/allocator/src/lib.rs`, find the `Deposit` context struct. Change `user_usdc` and `user_shares`:
+
+```rust
+// BEFORE
+/// User's USDC token account (source)
+#[account(mut)]
+pub user_usdc: Account<'info, TokenAccount>,
+
+/// User's share token account (destination for minted shares)
+#[account(mut)]
+pub user_shares: Account<'info, TokenAccount>,
+
+// AFTER
+/// User's USDC token account (source) — constrained to correct mint
+#[account(
+    mut,
+    token::mint = usdc_mint,
+    token::authority = user,
+)]
+pub user_usdc: Account<'info, TokenAccount>,
+
+/// User's share token account (destination for minted shares) — constrained
+#[account(
+    mut,
+    token::mint = share_mint,
+    token::authority = user,
+)]
+pub user_shares: Account<'info, TokenAccount>,
+```
+
+- [ ] **Step 2: Add constraints to Withdraw context**
+
+In the same file, find the `Withdraw` context struct. Change `user_shares` and `user_usdc`:
+
+```rust
+// BEFORE
+/// User's share token account (shares to burn)
+#[account(mut)]
+pub user_shares: Account<'info, TokenAccount>,
+
+/// User's USDC token account (receives withdrawal)
+#[account(mut)]
+pub user_usdc: Account<'info, TokenAccount>,
+
+// AFTER
+/// User's share token account (shares to burn) — constrained
+#[account(
+    mut,
+    token::mint = share_mint,
+    token::authority = user,
+)]
+pub user_shares: Account<'info, TokenAccount>,
+
+/// User's USDC token account (receives withdrawal) — constrained
+#[account(
+    mut,
+    token::mint = usdc_mint,
+    token::authority = user,
+)]
+pub user_usdc: Account<'info, TokenAccount>,
+```
+
+- [ ] **Step 3: Add constraints to AllocateToProtocol context**
+
+Find the `AllocateToProtocol` context struct. Change `protocol_usdc`:
+
+```rust
+// BEFORE
+/// Protocol's USDC token account (destination)
+#[account(mut)]
+pub protocol_usdc: Account<'info, TokenAccount>,
+
+// AFTER
+/// Protocol's USDC token account (destination) — constrained to correct mint
+#[account(
+    mut,
+    token::mint = usdc_mint,
+)]
+pub protocol_usdc: Account<'info, TokenAccount>,
+```
+
+Note: No `token::authority` constraint on `protocol_usdc` because the protocol controls its own authority — we only verify the mint is USDC.
+
+- [ ] **Step 4: Add constraints to RecallFromProtocol context**
+
+Find the `RecallFromProtocol` context struct. Change `protocol_usdc`:
+
+```rust
+// BEFORE
+/// Protocol's USDC token account (source)
+#[account(mut)]
+pub protocol_usdc: Account<'info, TokenAccount>,
+
+// AFTER
+/// Protocol's USDC token account (source) — constrained to correct mint
+#[account(
+    mut,
+    token::mint = usdc_mint,
+)]
+pub protocol_usdc: Account<'info, TokenAccount>,
+```
+
+- [ ] **Step 5: Build and verify**
+
+```bash
+cd ~/local-dev/nanuqfi
+cargo build-sbf --manifest-path programs/allocator/Cargo.toml --features devnet
+```
+
+Expected: Build succeeds with no errors.
+
+- [ ] **Step 6: Run Rust tests**
+
+```bash
+cd ~/local-dev/nanuqfi
+cargo test --manifest-path programs/allocator/Cargo.toml --features devnet
+```
+
+Expected: All 98 tests pass. Existing tests already use correct mints, so adding constraints won't break them.
+
+- [ ] **Step 7: Run TypeScript tests**
+
+```bash
+cd ~/local-dev/nanuqfi
+pnpm turbo test
+```
+
+Expected: All 209 TypeScript tests pass (core + backends + backtest).
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd ~/local-dev/nanuqfi
+git add programs/allocator/src/lib.rs
+git commit -m "fix(program): add token::mint and token::authority constraints
+
+Add missing constraints to prevent token substitution attacks:
+- Deposit: user_usdc (mint=usdc, auth=user), user_shares (mint=shares, auth=user)
+- Withdraw: user_shares (mint=shares, auth=user), user_usdc (mint=usdc, auth=user)
+- AllocateToProtocol: protocol_usdc (mint=usdc)
+- RecallFromProtocol: protocol_usdc (mint=usdc)
+
+Closes #30"
+```
+
+---
+
+## Task 3: Fix #21 — Create RPC proxy to hide Helius API key
+
+**Repo:** `nanuqfi/nanuqfi-app` (`~/local-dev/nanuqfi-app/`)
+
+**Files:**
+- Create: `src/app/api/rpc/route.ts`
+- Modify: `src/providers/solana-provider.tsx`
+- Modify: `.env.local`
+- Create: `.env.example`
+- Test: `src/app/api/rpc/__tests__/route.test.ts`
+
+- [ ] **Step 1: Create branch**
+
+```bash
+cd ~/local-dev/nanuqfi-app
+git checkout -b fix/p0-critical-hardening
+```
+
+- [ ] **Step 2: Write the failing test for RPC proxy**
+
+Create `src/app/api/rpc/__tests__/route.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock fetch globally
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+describe('RPC proxy route', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.stubEnv('HELIUS_RPC_URL', 'https://devnet.helius-rpc.com/?api-key=test-key')
+  })
+
+  it('forwards valid JSON-RPC POST to Helius and returns response', async () => {
+    const rpcResponse = { jsonrpc: '2.0', result: 'ok', id: 1 }
+    mockFetch.mockResolvedValueOnce({
+      status: 200,
+      text: () => Promise.resolve(JSON.stringify(rpcResponse)),
+    })
+
+    const { POST } = await import('../route')
+    const request = new Request('http://localhost:3000/api/rpc', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', method: 'getHealth', id: 1 }),
+    })
+
+    const response = await POST(request as any)
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data).toEqual(rpcResponse)
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://devnet.helius-rpc.com/?api-key=test-key',
+      expect.objectContaining({ method: 'POST' }),
+    )
+  })
+
+  it('returns 503 when HELIUS_RPC_URL is not configured', async () => {
+    vi.stubEnv('HELIUS_RPC_URL', '')
+
+    // Re-import to pick up new env
+    vi.resetModules()
+    const { POST } = await import('../route')
+    const request = new Request('http://localhost:3000/api/rpc', {
+      method: 'POST',
+      body: '{}',
+    })
+
+    const response = await POST(request as any)
+    expect(response.status).toBe(503)
+  })
+})
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+```bash
+cd ~/local-dev/nanuqfi-app
+pnpm vitest run src/app/api/rpc/__tests__/route.test.ts
+```
+
+Expected: FAIL — `route.ts` does not exist yet.
+
+- [ ] **Step 4: Create the RPC proxy route**
+
+Create `src/app/api/rpc/route.ts`:
+
+```typescript
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function POST(request: NextRequest) {
+  const rpcUrl = process.env.HELIUS_RPC_URL
+
+  if (!rpcUrl) {
+    return NextResponse.json(
+      { jsonrpc: '2.0', error: { code: -32603, message: 'RPC endpoint not configured' }, id: null },
+      { status: 503 },
+    )
+  }
+
+  const body = await request.text()
+
+  const response = await fetch(rpcUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body,
+  })
+
+  const data = await response.text()
+  return new NextResponse(data, {
+    status: response.status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+```bash
+cd ~/local-dev/nanuqfi-app
+pnpm vitest run src/app/api/rpc/__tests__/route.test.ts
+```
+
+Expected: PASS — both tests green.
+
+- [ ] **Step 6: Update SolanaProvider to use proxy**
+
+In `src/providers/solana-provider.tsx`, change the RPC URL:
+
+```typescript
+// BEFORE
+const RPC_URL = process.env.NEXT_PUBLIC_RPC_URL ?? 'https://api.devnet.solana.com'
+
+// AFTER
+const RPC_URL = '/api/rpc'
+```
+
+- [ ] **Step 7: Update environment files**
+
+Update `.env.local` — rename the variable (remove `NEXT_PUBLIC_` prefix):
+
+```bash
+# BEFORE
+NEXT_PUBLIC_RPC_URL=https://devnet.helius-rpc.com/?api-key=9350fa8c-7f70-44f7-b90c-b4022228821e
+
+# AFTER
+HELIUS_RPC_URL=https://devnet.helius-rpc.com/?api-key=9350fa8c-7f70-44f7-b90c-b4022228821e
+```
+
+Create `.env.example` with safe defaults (no real keys):
+
+```bash
+# Solana RPC endpoint (server-side only — never use NEXT_PUBLIC_ for keys)
+HELIUS_RPC_URL=https://api.devnet.solana.com
+
+# Public config (safe to expose)
+NEXT_PUBLIC_ALLOCATOR_PROGRAM_ID=2QtJ5kmxLuW2jYCFpJMtzZ7PCnKdoMwkeueYoDUi5z5P
+NEXT_PUBLIC_USDC_MINT=BiTXT15XyfSakk5Yz8L8QrzHPWbK8NjoZeEMFrDvKdKh
+NEXT_PUBLIC_KEEPER_API_URL=http://localhost:3001
+```
+
+- [ ] **Step 8: Verify no NEXT_PUBLIC_ vars contain API keys**
+
+```bash
+cd ~/local-dev/nanuqfi-app
+grep -r "NEXT_PUBLIC_RPC_URL" src/ || echo "CLEAN: no references found"
+grep -r "NEXT_PUBLIC_.*api.key\|NEXT_PUBLIC_.*helius" src/ --include="*.ts" --include="*.tsx" -i || echo "CLEAN: no exposed keys"
+```
+
+Expected: Both return "CLEAN".
+
+- [ ] **Step 9: Build verification**
+
+```bash
+cd ~/local-dev/nanuqfi-app
+pnpm build 2>&1 | tail -5
+```
+
+Expected: Build succeeds.
+
+- [ ] **Step 10: Commit**
+
+```bash
+cd ~/local-dev/nanuqfi-app
+git add src/app/api/rpc/route.ts src/app/api/rpc/__tests__/route.test.ts src/providers/solana-provider.tsx .env.example
+git add .env.local  # updated var name
+git commit -m "fix: move Helius RPC key to server-side proxy route
+
+NEXT_PUBLIC_RPC_URL exposed the Helius API key in the client bundle.
+Created /api/rpc server-side proxy that forwards JSON-RPC requests
+to Helius using the server-only HELIUS_RPC_URL env var.
+
+Added .env.example with safe defaults.
+
+Closes #21"
+```
+
+---
+
+## Task 4: Fix #22 — Use actual share price in withdraw calculations
+
+**Repo:** `nanuqfi/nanuqfi-app` (`~/local-dev/nanuqfi-app/`)
+
+**Files:**
+- Modify: `src/components/app/deposit-form.tsx`
+- Modify: `src/app/app/vaults/[riskLevel]/page.tsx`
+- Test: `src/components/app/__tests__/deposit-form.test.tsx` (or existing test file)
+
+The `sharePrice` is already computed in `useRiskVault()` as a float (e.g., `1.0`, `1.2`). It's used in the vault detail page for position valuation but NOT passed to `DepositForm`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create or update `src/components/app/__tests__/deposit-form-share-price.test.tsx`:
+
+```typescript
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { DepositForm } from '../deposit-form'
+
+// Mock wallet + connection
+vi.mock('@solana/wallet-adapter-react', () => ({
+  useWallet: () => ({ publicKey: null, sendTransaction: vi.fn() }),
+  useConnection: () => ({ connection: {} }),
+}))
+vi.mock('@/components/ui/toast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}))
+
+describe('DepositForm share price handling', () => {
+  const baseProps = {
+    riskLevel: 'moderate' as const,
+    riskLevelNum: 1,
+    apy: 0.08,
+    dailyEarnings: 0.22,
+  }
+
+  it('MAX button uses share price for withdraw USDC estimate', () => {
+    render(
+      <DepositForm
+        {...baseProps}
+        userShares={100_000_000n}  // 100 shares (6 decimals)
+        sharePrice={1.2}           // 1 share = 1.2 USDC
+      />,
+    )
+
+    // Switch to withdraw mode
+    fireEvent.click(screen.getByText('Withdraw'))
+    // Click MAX
+    fireEvent.click(screen.getByText('MAX'))
+
+    const input = screen.getByPlaceholderText('0.00') as HTMLInputElement
+    // 100 shares * 1.2 price = 120 USDC
+    expect(Number(input.value)).toBeCloseTo(120, 1)
+  })
+
+  it('MAX button defaults to 1:1 when sharePrice not provided', () => {
+    render(
+      <DepositForm
+        {...baseProps}
+        userShares={100_000_000n}
+      />,
+    )
+
+    fireEvent.click(screen.getByText('Withdraw'))
+    fireEvent.click(screen.getByText('MAX'))
+
+    const input = screen.getByPlaceholderText('0.00') as HTMLInputElement
+    // 100 shares * 1.0 price = 100 USDC
+    expect(Number(input.value)).toBeCloseTo(100, 1)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd ~/local-dev/nanuqfi-app
+pnpm vitest run src/components/app/__tests__/deposit-form-share-price.test.tsx
+```
+
+Expected: FAIL — `sharePrice` prop doesn't exist on DepositForm.
+
+- [ ] **Step 3: Add sharePrice prop to DepositForm**
+
+In `src/components/app/deposit-form.tsx`, update the interface and logic:
+
+```typescript
+// BEFORE (interface)
+interface DepositFormProps {
+  riskLevel: RiskLevel
+  riskLevelNum: number
+  apy: number
+  dailyEarnings: number
+  walletBalance?: number
+  shareMint?: PublicKey
+  userShares?: bigint
+  redemptionPeriodSlots?: bigint
+  onSuccess?: () => void
+}
+
+// AFTER (interface)
+interface DepositFormProps {
+  riskLevel: RiskLevel
+  riskLevelNum: number
+  apy: number
+  dailyEarnings: number
+  walletBalance?: number
+  shareMint?: PublicKey
+  userShares?: bigint
+  sharePrice?: number
+  redemptionPeriodSlots?: bigint
+  onSuccess?: () => void
+}
+```
+
+Update the destructured props:
+
+```typescript
+// BEFORE
+}: DepositFormProps) {
+
+// AFTER — add sharePrice to destructuring
+  sharePrice,
+}: DepositFormProps) {
+```
+
+Update `handleMax()`:
+
+```typescript
+// BEFORE
+  } else if (mode === 'withdraw' && userShares !== undefined && userShares > 0n) {
+    // Convert shares back to approximate USDC for display
+    // Share price ~1:1 at initialization, so shares / 1e6 gives USDC
+    setAmount(String(Number(userShares) / 10 ** USDC_DECIMALS))
+  }
+
+// AFTER
+  } else if (mode === 'withdraw' && userShares !== undefined && userShares > 0n) {
+    // Convert shares to USDC using actual share price
+    const price = sharePrice ?? 1
+    setAmount(String(Number(userShares) * price / 10 ** USDC_DECIMALS))
+  }
+```
+
+Update `handleWithdraw()` — convert USDC input to shares using price:
+
+```typescript
+// BEFORE
+    // Convert entered USDC amount to shares
+    // For simplicity, treat 1 share = 1 USDC smallest unit at 1:1 price
+    const sharesAmount = BigInt(Math.round(parsedAmount * 10 ** USDC_DECIMALS))
+
+// AFTER
+    // Convert entered USDC amount to shares using actual share price
+    const price = sharePrice ?? 1
+    const sharesAmount = BigInt(Math.round(parsedAmount / price * 10 ** USDC_DECIMALS))
+```
+
+Update the shares display label in the withdraw tab to show USDC value:
+
+```typescript
+// BEFORE
+          {mode === 'withdraw' && userShares !== undefined && (
+            <span className="text-xs text-slate-500 font-mono">
+              Shares: {(Number(userShares) / 10 ** USDC_DECIMALS).toLocaleString('en-US', { maximumFractionDigits: 2 })}
+            </span>
+          )}
+
+// AFTER
+          {mode === 'withdraw' && userShares !== undefined && (
+            <span className="text-xs text-slate-500 font-mono">
+              Value: {(Number(userShares) * (sharePrice ?? 1) / 10 ** USDC_DECIMALS).toLocaleString('en-US', { maximumFractionDigits: 2 })} USDC
+            </span>
+          )}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd ~/local-dev/nanuqfi-app
+pnpm vitest run src/components/app/__tests__/deposit-form-share-price.test.tsx
+```
+
+Expected: PASS — both share price tests green.
+
+- [ ] **Step 5: Pass sharePrice from vault detail page**
+
+In `src/app/app/vaults/[riskLevel]/page.tsx`, find where `DepositForm` is rendered and add `sharePrice`:
+
+```typescript
+// BEFORE
+          <DepositForm
+            riskLevel={riskLevel}
+            riskLevelNum={riskLevelNum}
+            apy={apy}
+            dailyEarnings={dailyEarnings}
+            walletBalance={walletBalance}
+            shareMint={onChain.data?.shareMint}
+            userShares={userPosition.data?.shares}
+            redemptionPeriodSlots={onChain.data?.redemptionPeriodSlots}
+            onSuccess={() => {
+
+// AFTER
+          <DepositForm
+            riskLevel={riskLevel}
+            riskLevelNum={riskLevelNum}
+            apy={apy}
+            dailyEarnings={dailyEarnings}
+            walletBalance={walletBalance}
+            shareMint={onChain.data?.shareMint}
+            userShares={userPosition.data?.shares}
+            sharePrice={onChain.data?.sharePrice}
+            redemptionPeriodSlots={onChain.data?.redemptionPeriodSlots}
+            onSuccess={() => {
+```
+
+- [ ] **Step 6: Run full test suite**
+
+```bash
+cd ~/local-dev/nanuqfi-app
+pnpm vitest run
+```
+
+Expected: All tests pass (existing 62 + 2 new = 64).
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd ~/local-dev/nanuqfi-app
+git add src/components/app/deposit-form.tsx src/app/app/vaults/\\[riskLevel\\]/page.tsx src/components/app/__tests__/deposit-form-share-price.test.tsx
+git commit -m "fix: use actual share price in withdraw calculations
+
+MAX button and withdraw amount conversion assumed 1:1 share price.
+Now uses on-chain sharePrice from useRiskVault() hook.
+Formula: usdcValue = shares * sharePrice / 1e6
+
+Closes #22"
+```
+
+---
+
+## Task 5: Fix #9 — Await rebalance and handle tx failure
+
+**Repo:** `nanuqfi/nanuqfi-keeper` (`~/local-dev/nanuqfi-keeper/`)
+
+**Files:**
+- Modify: `src/keeper.ts` (KeeperDecision interface + runCycle method)
+- Test: `src/__tests__/keeper-rebalance.test.ts` (new)
+
+- [ ] **Step 1: Create branch**
+
+```bash
+cd ~/local-dev/nanuqfi-keeper
+git checkout -b fix/p0-critical-hardening
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `src/__tests__/keeper-rebalance.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock all external dependencies
+vi.mock('../chain/rebalance', () => ({
+  submitRebalance: vi.fn(),
+}))
+vi.mock('../ai/prompt-builder', () => ({
+  buildInsightPrompt: vi.fn().mockReturnValue('test prompt'),
+}))
+vi.mock('../market/scanner', () => ({
+  scanDeFiYields: vi.fn().mockResolvedValue({ protocols: [] }),
+}))
+
+import { submitRebalance } from '../chain/rebalance'
+import type { KeeperDecision } from '../keeper'
+
+const mockSubmitRebalance = vi.mocked(submitRebalance)
+
+describe('keeper rebalance awaiting', () => {
+  let keeper: any
+
+  beforeEach(async () => {
+    vi.resetAllMocks()
+
+    // Dynamically import to get fresh instance
+    vi.resetModules()
+    const { NanuqKeeper } = await import('../keeper')
+    keeper = new NanuqKeeper({
+      rpcUrls: ['https://test-rpc.com'],
+      keeperKeypairPath: '/tmp/test-keypair.json',
+      cycleIntervalMs: 60_000,
+      aiEnabled: false,
+      alertTelegramToken: '',
+      alertTelegramChatId: '',
+    })
+
+    // Stub methods that touch external systems
+    keeper.fetchYieldData = vi.fn().mockResolvedValue({
+      kamino: { apy: 0.08, tvl: 1000000 },
+      marginfi: { apy: 0.065, tvl: 2000000 },
+      lulo: { apy: 0.07, tvl: 500000 },
+    })
+    keeper.alerter = { alert: vi.fn().mockResolvedValue(undefined) }
+    keeper.monitor = {
+      recordCycleSuccess: vi.fn(),
+      recordCycleFailure: vi.fn(),
+    }
+  })
+
+  it('does NOT record decision as confirmed when submitRebalance fails', async () => {
+    mockSubmitRebalance.mockResolvedValue({
+      success: false,
+      error: 'Transaction simulation failed',
+    })
+
+    await keeper.runCycle()
+
+    // Decisions should exist but be marked as failed
+    const decisions: KeeperDecision[] = keeper.decisions
+    const failedDecisions = decisions.filter((d: KeeperDecision) => d.txStatus === 'failed')
+    expect(failedDecisions.length).toBeGreaterThan(0)
+
+    // No decision should be marked as confirmed
+    const confirmedDecisions = decisions.filter((d: KeeperDecision) => d.txStatus === 'confirmed')
+    expect(confirmedDecisions).toHaveLength(0)
+  })
+
+  it('records decision as confirmed when submitRebalance succeeds', async () => {
+    mockSubmitRebalance.mockResolvedValue({
+      success: true,
+      txSignature: 'abc123signature',
+    })
+
+    await keeper.runCycle()
+
+    const decisions: KeeperDecision[] = keeper.decisions
+    const confirmed = decisions.filter((d: KeeperDecision) => d.txStatus === 'confirmed')
+    expect(confirmed.length).toBeGreaterThan(0)
+    expect(confirmed[0].txSignature).toBe('abc123signature')
+  })
+
+  it('sends alert when rebalance tx fails', async () => {
+    mockSubmitRebalance.mockResolvedValue({
+      success: false,
+      error: 'Blockhash expired',
+    })
+
+    await keeper.runCycle()
+
+    expect(keeper.alerter.alert).toHaveBeenCalledWith(
+      expect.stringContaining('rebalance failed'),
+    )
+  })
+
+  it('does NOT update currentWeights when tx fails', async () => {
+    const originalWeights = { ...keeper.currentWeights }
+    mockSubmitRebalance.mockResolvedValue({
+      success: false,
+      error: 'Simulation failed',
+    })
+
+    await keeper.runCycle()
+
+    // Weights should not have changed for vaults with failed tx
+    // (they may still change for algorithm-only mode)
+    const failedDecisions: KeeperDecision[] = keeper.decisions.filter(
+      (d: KeeperDecision) => d.txStatus === 'failed',
+    )
+    for (const d of failedDecisions) {
+      expect(keeper.currentWeights[d.riskLevel]).toEqual(
+        originalWeights[d.riskLevel] ?? {},
+      )
+    }
+  })
+})
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+```bash
+cd ~/local-dev/nanuqfi-keeper
+pnpm vitest run src/__tests__/keeper-rebalance.test.ts
+```
+
+Expected: FAIL — `txStatus` property doesn't exist on `KeeperDecision`.
+
+- [ ] **Step 4: Add txStatus to KeeperDecision interface**
+
+In `src/keeper.ts`, update the `KeeperDecision` interface:
+
+```typescript
+// BEFORE
+export interface KeeperDecision {
+  timestamp: number
+  riskLevel: string
+  proposal: WeightProposal
+  yieldData: YieldData
+  aiInsight?: AIInsight
+  txSignature?: string
+}
+
+// AFTER
+export interface KeeperDecision {
+  timestamp: number
+  riskLevel: string
+  proposal: WeightProposal
+  yieldData: YieldData
+  aiInsight?: AIInsight
+  txSignature?: string
+  txStatus?: 'pending' | 'confirmed' | 'failed'
+}
+```
+
+- [ ] **Step 5: Rewrite submitRebalance call to await**
+
+In `src/keeper.ts`, replace the fire-and-forget block in `runCycle()`. Find the section inside the `for (const riskLevel of vaults)` loop that starts with `// Submit rebalance tx`:
+
+```typescript
+// ─── BEFORE (fire-and-forget) ─────────────────────────────────────────
+
+      // Submit rebalance tx to on-chain allocator (if keypair configured)
+      if (this.config.keeperKeypairPath && this.config.rpcUrls[0]) {
+        const reasoning = this.getAIInsight()?.reasoning ?? 'Algorithm-only rebalance'
+        submitRebalance({
+          rpcUrl: this.config.rpcUrls[0],
+          keypairPath: this.config.keeperKeypairPath,
+          riskLevel,
+          weights: proposal.weights,
+          reasoning,
+          rebalanceCounter: this.decisions.length,
+          equitySnapshot: 0n,
+          vaultUsdcAddress: new (await import('@solana/web3.js')).PublicKey('11111111111111111111111111111111'),
+          treasuryUsdcAddress: new (await import('@solana/web3.js')).PublicKey('11111111111111111111111111111111'),
+        }).then(result => {
+          if (result.success) {
+            console.log(`[Chain] Rebalance tx submitted: ${result.txSignature}`)
+            // Store tx in the latest decision
+            const lastDecision = this.decisions[this.decisions.length - 1]
+            if (lastDecision) lastDecision.txSignature = result.txSignature
+          } else {
+            console.warn(`[Chain] Rebalance tx failed: ${result.error}`)
+            this.alerter.alert(`❌ On-chain rebalance failed: ${result.error}`).catch(() => {})
+          }
+        }).catch(err => {
+          console.warn(`[Chain] Rebalance submission error: ${err instanceof Error ? err.message : err}`)
+        })
+      }
+
+// ─── AFTER (awaited with proper status tracking) ──────────────────────
+
+      // Submit rebalance tx to on-chain allocator (if keypair configured)
+      if (this.config.keeperKeypairPath && this.config.rpcUrls[0]) {
+        const reasoning = this.getAIInsight()?.reasoning ?? 'Algorithm-only rebalance'
+        const decision = this.decisions[this.decisions.length - 1]
+
+        try {
+          const result = await submitRebalance({
+            rpcUrl: this.config.rpcUrls[0],
+            keypairPath: this.config.keeperKeypairPath,
+            riskLevel,
+            weights: proposal.weights,
+            reasoning,
+            rebalanceCounter: this.decisions.length,
+            equitySnapshot: 0n,
+            vaultUsdcAddress: new (await import('@solana/web3.js')).PublicKey('11111111111111111111111111111111'),
+            treasuryUsdcAddress: new (await import('@solana/web3.js')).PublicKey('11111111111111111111111111111111'),
+          })
+
+          if (result.success) {
+            if (decision) {
+              decision.txSignature = result.txSignature
+              decision.txStatus = 'confirmed'
+            }
+            this.currentWeights[riskLevel] = proposal.weights
+            console.log(`[Chain] Rebalance tx confirmed: ${result.txSignature}`)
+          } else {
+            if (decision) decision.txStatus = 'failed'
+            console.error(`[Chain] Rebalance tx failed for ${riskLevel}: ${result.error}`)
+            await this.alerter.alert(`❌ On-chain rebalance failed for ${riskLevel}: ${result.error}`)
+          }
+        } catch (err) {
+          if (decision) decision.txStatus = 'failed'
+          const msg = err instanceof Error ? err.message : String(err)
+          console.error(`[Chain] Rebalance submission error for ${riskLevel}: ${msg}`)
+          await this.alerter.alert(`❌ On-chain rebalance error for ${riskLevel}: ${msg}`)
+        }
+      } else {
+        // Algorithm-only mode — no on-chain tx, update weights directly
+        this.currentWeights[riskLevel] = proposal.weights
+      }
+```
+
+Also, move the `this.currentWeights[riskLevel] = proposal.weights` line that's BEFORE the submit block — it must be removed from its current position (before the if block) since we now set it conditionally inside. Find and remove:
+
+```typescript
+// REMOVE this line (currently before the submit block):
+      this.currentWeights[riskLevel] = proposal.weights
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+```bash
+cd ~/local-dev/nanuqfi-keeper
+pnpm vitest run src/__tests__/keeper-rebalance.test.ts
+```
+
+Expected: PASS — all 4 tests green.
+
+- [ ] **Step 7: Run full test suite**
+
+```bash
+cd ~/local-dev/nanuqfi-keeper
+pnpm vitest run
+```
+
+Expected: All 206+ tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd ~/local-dev/nanuqfi-keeper
+git add src/keeper.ts src/__tests__/keeper-rebalance.test.ts
+git commit -m "fix: await rebalance tx and track confirmation status
+
+submitRebalance was fire-and-forget — cycle logged success before
+tx confirmed. Now awaits the result and:
+- On success: marks decision as 'confirmed', updates weights
+- On failure: marks as 'failed', keeps old weights, sends alert
+- Algorithm-only mode (no keypair): updates weights directly
+
+Added txStatus field to KeeperDecision interface.
+
+Closes #9"
+```
+
+---
+
+## Task 6: Push branches and create PRs
+
+- [ ] **Step 1: Push nanuqfi core branch**
+
+```bash
+cd ~/local-dev/nanuqfi
+git push -u origin fix/p0-critical-hardening
+```
+
+- [ ] **Step 2: Push nanuqfi-app branch**
+
+```bash
+cd ~/local-dev/nanuqfi-app
+git push -u origin fix/p0-critical-hardening
+```
+
+- [ ] **Step 3: Push nanuqfi-keeper branch**
+
+```bash
+cd ~/local-dev/nanuqfi-keeper
+git push -u origin fix/p0-critical-hardening
+```
+
+- [ ] **Step 4: Create PRs (3 total)**
+
+Core PR:
+```bash
+cd ~/local-dev/nanuqfi
+gh pr create --title "fix: P0-critical security hardening (#29, #30)" --body "## Summary
+- Remove devnet from default Cargo features — admin instructions no longer leak to mainnet (#29)
+- Add token::mint and token::authority constraints on user_usdc, user_shares, protocol_usdc (#30)
+
+## Test plan
+- [ ] cargo build-sbf (no features) succeeds without devnet admin instructions
+- [ ] cargo build-sbf --features devnet still compiles all instructions
+- [ ] cargo test --features devnet — all 98 tests pass
+- [ ] pnpm turbo test — all TS tests pass"
+```
+
+App PR:
+```bash
+cd ~/local-dev/nanuqfi-app
+gh pr create --title "fix: P0-critical RPC key exposure + share price bug (#21, #22)" --body "## Summary
+- Move Helius RPC key from NEXT_PUBLIC_ to server-side /api/rpc proxy (#21)
+- Use actual on-chain share price in withdraw calculations (#22)
+
+## Test plan
+- [ ] pnpm build succeeds
+- [ ] grep NEXT_PUBLIC_RPC_URL src/ returns zero hits
+- [ ] RPC proxy test passes
+- [ ] Share price test: 1.2x price, 100 shares = 120 USDC
+- [ ] pnpm vitest run — all tests pass"
+```
+
+Keeper PR:
+```bash
+cd ~/local-dev/nanuqfi-keeper
+gh pr create --title "fix: P0-critical fire-and-forget rebalance (#9)" --body "## Summary
+- Await submitRebalance instead of fire-and-forget
+- Track txStatus (pending/confirmed/failed) on KeeperDecision
+- Send Telegram alert on tx failure
+- Only update currentWeights on confirmed tx
+
+## Test plan
+- [ ] Failed tx → decision marked 'failed', weights unchanged
+- [ ] Successful tx → decision marked 'confirmed', weights updated
+- [ ] Failed tx → alert sent
+- [ ] pnpm vitest run — all tests pass"
+```

--- a/docs/superpowers/specs/2026-04-10-p0-critical-fixes-design.md
+++ b/docs/superpowers/specs/2026-04-10-p0-critical-fixes-design.md
@@ -1,0 +1,172 @@
+# P0-Critical Fixes Design Spec
+
+**Date:** 2026-04-10
+**Scope:** 5 P0-critical issues across 3 repos (nanuqfi, nanuqfi-app, nanuqfi-keeper)
+**Approach:** Fix + verify (each fix includes a test proving it works)
+**Branching:** One `fix/p0-critical-hardening` branch per repo (3 branches, 3 PRs)
+
+---
+
+## Issues Covered
+
+| # | Repo | Title | Risk |
+|---|------|-------|------|
+| #30 | nanuqfi | Missing token::mint and token::authority constraints | Token substitution attack |
+| #29 | nanuqfi | Devnet feature in default Cargo features | Admin instructions leak to mainnet |
+| #21 | nanuqfi-app | NEXT_PUBLIC_ exposes Helius RPC API key | API key in client bundle |
+| #22 | nanuqfi-app | Withdraw assumes 1:1 share price | Incorrect fund display/loss |
+| #9 | nanuqfi-keeper | Fire-and-forget rebalance | On-chain state divergence |
+
+---
+
+## Repo 1: nanuqfi/nanuqfi
+
+### Fix #29 — Remove devnet from default Cargo features
+
+**Problem:** `default = ["devnet"]` in `programs/allocator/Cargo.toml` means `admin_reset_vault`, `admin_set_tvl`, and `admin_set_rebalance_counter` compile into mainnet builds. Compromised admin key = nuke vault accounting.
+
+**Fix:**
+- `programs/allocator/Cargo.toml`: `default = ["devnet"]` -> `default = []`
+
+**Verification:**
+- `cargo build` (no features) must succeed without devnet admin instructions
+- `cargo build --features devnet` must still compile them for testing
+- Existing `anchor test` passes (tests use `--features devnet` via Anchor.toml)
+
+### Fix #30 — Add token mint/authority constraints
+
+**Problem:** `user_usdc`, `user_shares`, and `protocol_usdc` token accounts in Deposit, Withdraw, AllocateToProtocol, and RecallFromProtocol have no `token::mint` or `token::authority` constraints. An attacker can pass fake-mint token accounts to steal or redirect funds.
+
+**Affected instruction contexts and required constraints:**
+
+#### Deposit context
+```rust
+// user_usdc: add token::mint constraint
+#[account(mut, token::mint = allocator.usdc_mint)]
+pub user_usdc: Account<'info, TokenAccount>,
+
+// user_shares: add token::mint + token::authority constraints
+#[account(mut, token::mint = risk_vault.share_mint, token::authority = user)]
+pub user_shares: Account<'info, TokenAccount>,
+```
+
+#### Withdraw context
+```rust
+// user_usdc: add token::mint constraint
+#[account(mut, token::mint = allocator.usdc_mint)]
+pub user_usdc: Account<'info, TokenAccount>,
+
+// user_shares: add token::mint + token::authority constraints
+#[account(mut, token::mint = risk_vault.share_mint, token::authority = user)]
+pub user_shares: Account<'info, TokenAccount>,
+```
+
+#### AllocateToProtocol context
+```rust
+// protocol_usdc: add token::mint constraint
+#[account(mut, token::mint = allocator.usdc_mint)]
+pub protocol_usdc: Account<'info, TokenAccount>,
+```
+
+#### RecallFromProtocol context
+```rust
+// protocol_usdc: add token::mint constraint
+#[account(mut, token::mint = allocator.usdc_mint)]
+pub protocol_usdc: Account<'info, TokenAccount>,
+```
+
+**Prerequisite:** Verify `allocator.usdc_mint` field exists in the Allocator state struct. If not, it must be added (set during `initialize_allocator`) and the USDC mint passed as an account. Similarly verify `risk_vault.share_mint` is accessible in each context.
+
+**Verification:**
+- `anchor build` succeeds
+- `anchor test` passes (existing tests already use correct mints)
+- Add negative test: pass wrong-mint token account to Deposit -> expect `ConstraintTokenMint` error
+
+---
+
+## Repo 2: nanuqfi/nanuqfi-app
+
+### Fix #21 — Remove RPC API key from client bundle
+
+**Problem:** `NEXT_PUBLIC_RPC_URL` embeds the Helius API key in the client JavaScript bundle. Anyone can extract it from browser DevTools.
+
+**Fix:**
+1. Create server-side RPC proxy route: `src/app/api/rpc/route.ts`
+   - Reads `HELIUS_RPC_URL` (no `NEXT_PUBLIC_` prefix) from server env
+   - Accepts POST with JSON-RPC body, forwards to Helius, returns response
+   - Basic validation: reject non-POST, validate JSON-RPC structure
+   - Rate limit consideration: rely on Helius rate limits for now (devnet)
+2. Update `src/providers/solana-provider.tsx`:
+   - Change endpoint from `NEXT_PUBLIC_RPC_URL` to `/api/rpc`
+3. Update environment files:
+   - Rename `NEXT_PUBLIC_RPC_URL` -> `HELIUS_RPC_URL` in `.env`, `.env.example`
+   - Remove any other `NEXT_PUBLIC_` vars that contain API keys
+4. Update Vercel/deployment env vars if applicable
+
+**Verification:**
+- `pnpm build` succeeds with no `NEXT_PUBLIC_RPC_URL` references
+- `grep -r "NEXT_PUBLIC_RPC_URL"` returns zero hits in src/
+- RPC proxy route test: POST valid JSON-RPC -> 200, GET -> 405
+
+### Fix #22 — Use actual share price in withdraw
+
+**Problem:** `deposit-form.tsx` line 76 uses `shares / 1e6` for the MAX button and amount display, assuming 1:1 share price. The on-chain program uses: `effective_price = min(current_price, request_time_price)` and `gross_usdc = shares * effective_price / 1_000_000`.
+
+**Fix:**
+1. Pass `sharePrice` (already fetched in vault detail page via on-chain data) into `DepositForm` as a prop
+2. Update MAX button: `setAmount(String(Number(userShares) * sharePrice / 1e6 / 1e6))`
+   - First `/1e6` converts from raw shares to share units
+   - `* sharePrice / 1e6` applies the price (SHARE_PRICE_PRECISION = 1_000_000)
+3. Update withdraw amount display to show estimated USDC using share price
+4. Add a "Share Price" indicator in the form so users can see the current rate
+
+**Verification:**
+- Unit test: sharePrice = 1_200_000 (1.2x), 100 shares -> expect 120 USDC display
+- Unit test: sharePrice = 1_000_000 (1.0x), 100 shares -> expect 100 USDC display
+- Visual: MAX button shows correct USDC value when share price != 1.0
+
+---
+
+## Repo 3: nanuqfi/nanuqfi-keeper
+
+### Fix #9 — Await rebalance and verify on-chain state
+
+**Problem:** `submitRebalance()` in `keeper.ts` is called without `await`. The cycle logs "success" and records the decision before knowing if the transaction confirmed. If the tx fails silently, the keeper's internal weights diverge from on-chain state, and rebalance counter gets out of sync.
+
+**Fix:**
+1. `keeper.ts` `runCycle()`: replace fire-and-forget with `await submitRebalance()`
+2. On tx failure:
+   - Do NOT record decision as "executed"
+   - Log error with full context (weights, counter, error)
+   - Send Telegram alert: "Rebalance tx failed: {error}"
+   - Mark cycle as failed in decision history
+3. On tx success:
+   - Verify: fetch on-chain allocator account, compare actual weights to submitted weights
+   - If diverged: log warning + Telegram alert, mark as "unverified"
+   - If matched: mark as "confirmed"
+4. Add `verifyOnChainState()` helper:
+   - Fetches allocator + risk vault accounts
+   - Compares total_assets, allocation percentages
+   - Returns `{ matched: boolean, divergences: string[] }`
+
+**Verification:**
+- Unit test: mock `submitRebalance` rejection -> decision NOT recorded as success
+- Unit test: mock `submitRebalance` success + verification match -> decision marked "confirmed"
+- Unit test: mock `submitRebalance` success + verification mismatch -> decision marked "unverified" + alert sent
+
+---
+
+## Out of Scope
+
+- P1-hardening issues (separate pass)
+- Mainnet migration (separate initiative)
+- Rate limiting on RPC proxy (rely on Helius limits for devnet)
+- Full reconciliation loop in keeper (this fix adds one-shot verification, not continuous reconciliation)
+
+## Risk Assessment
+
+- **#29** is a one-line change with zero regression risk
+- **#30** may require adding `usdc_mint` to the Allocator struct if it doesn't exist — this would change account layout and require migration or redeploy
+- **#21** changes how the frontend connects to RPC — test thoroughly, Solana wallet adapter must work with proxy
+- **#22** is UI math — low risk, high impact on correctness
+- **#9** changes the keeper's core loop timing — awaiting tx means longer cycles, but correctness > speed

--- a/programs/allocator/Cargo.toml
+++ b/programs/allocator/Cargo.toml
@@ -13,7 +13,7 @@ no-entrypoint = []
 no-idl = []
 no-log-ix-name = []
 cpi = ["no-entrypoint"]
-default = ["devnet"]
+default = []
 devnet = []
 idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]
 

--- a/programs/allocator/src/lib.rs
+++ b/programs/allocator/src/lib.rs
@@ -1181,12 +1181,20 @@ pub struct Deposit<'info> {
   /// USDC mint (for vault_usdc constraint validation)
   pub usdc_mint: Account<'info, Mint>,
 
-  /// User's USDC token account (source)
-  #[account(mut)]
+  /// User's USDC token account (source) — constrained to correct mint
+  #[account(
+    mut,
+    token::mint = usdc_mint,
+    token::authority = user,
+  )]
   pub user_usdc: Account<'info, TokenAccount>,
 
-  /// User's share token account (destination for minted shares)
-  #[account(mut)]
+  /// User's share token account (destination for minted shares) — constrained
+  #[account(
+    mut,
+    token::mint = share_mint,
+    token::authority = user,
+  )]
   pub user_shares: Account<'info, TokenAccount>,
 
   /// Vault's USDC token account — constrained to correct mint + authority
@@ -1265,12 +1273,20 @@ pub struct Withdraw<'info> {
   /// USDC mint (for vault_usdc constraint validation)
   pub usdc_mint: Account<'info, Mint>,
 
-  /// User's share token account (shares to burn)
-  #[account(mut)]
+  /// User's share token account (shares to burn) — constrained
+  #[account(
+    mut,
+    token::mint = share_mint,
+    token::authority = user,
+  )]
   pub user_shares: Account<'info, TokenAccount>,
 
-  /// User's USDC token account (receives withdrawal)
-  #[account(mut)]
+  /// User's USDC token account (receives withdrawal) — constrained
+  #[account(
+    mut,
+    token::mint = usdc_mint,
+    token::authority = user,
+  )]
   pub user_usdc: Account<'info, TokenAccount>,
 
   /// Vault's USDC token account — constrained to correct mint + authority
@@ -1579,8 +1595,11 @@ pub struct AllocateToProtocol<'info> {
     token::authority = allocator,
   )]
   pub vault_usdc: Account<'info, TokenAccount>,
-  /// Protocol's USDC token account (destination)
-  #[account(mut)]
+  /// Protocol's USDC token account (destination) — constrained to correct mint
+  #[account(
+    mut,
+    token::mint = usdc_mint,
+  )]
   pub protocol_usdc: Account<'info, TokenAccount>,
   pub token_program: Program<'info, Token>,
 }
@@ -1595,8 +1614,11 @@ pub struct RecallFromProtocol<'info> {
   pub keeper: Signer<'info>,
   /// USDC mint (for vault_usdc constraint validation)
   pub usdc_mint: Account<'info, Mint>,
-  /// Protocol's USDC token account (source)
-  #[account(mut)]
+  /// Protocol's USDC token account (source) — constrained to correct mint
+  #[account(
+    mut,
+    token::mint = usdc_mint,
+  )]
   pub protocol_usdc: Account<'info, TokenAccount>,
   /// Vault's USDC token account (destination) — constrained
   #[account(

--- a/programs/allocator/src/lib.rs
+++ b/programs/allocator/src/lib.rs
@@ -1614,10 +1614,11 @@ pub struct RecallFromProtocol<'info> {
   pub keeper: Signer<'info>,
   /// USDC mint (for vault_usdc constraint validation)
   pub usdc_mint: Account<'info, Mint>,
-  /// Protocol's USDC token account (source) — constrained to correct mint
+  /// Protocol's USDC token account (source) — constrained to correct mint + allocator authority
   #[account(
     mut,
     token::mint = usdc_mint,
+    token::authority = allocator,
   )]
   pub protocol_usdc: Account<'info, TokenAccount>,
   /// Vault's USDC token account (destination) — constrained


### PR DESCRIPTION
## Summary
- Remove `devnet` from default Cargo features — admin instructions no longer leak to mainnet (#29)
- Add `token::mint` and `token::authority` constraints on user_usdc, user_shares, protocol_usdc across Deposit, Withdraw, AllocateToProtocol, RecallFromProtocol (#30)
- Add CI steps for `--features devnet` build/test coverage

## Changes
- `programs/allocator/Cargo.toml`: `default = []` (was `["devnet"]`)
- `programs/allocator/src/lib.rs`: 7 token accounts constrained across 4 context structs
- `.github/workflows/ci.yml`: devnet feature build/test steps added

## Test plan
- [x] `cargo build-sbf` (no features) — excludes devnet admin instructions
- [x] `cargo build-sbf --features devnet` — all instructions compile
- [x] `cargo test --features devnet` — 99/99 pass
- [x] `pnpm turbo test` — 209 TS tests pass