### PR TITLE
chore: add AGENTS.md satellite context file

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,208 @@
+<!-- Satellite context file — extends the global hub (~/.claude/CLAUDE.md | ~/.pi/agent/AGENTS.md). Host-neutral; project-specific only. Do not duplicate hub standards here. -->
+
+# NanuqFi Ecosystem
+
+**Organization:** https://github.com/nanuqfi
+**Website:** nanuqfi.com
+
+This file holds ecosystem-wide context for AI agents working across all NanuqFi
+repositories, plus core-repository detail (the `nanuqfi/nanuqfi` repo is the SDK + Anchor program monorepo).
+
+## Ecosystem Overview
+
+NanuqFi is a protocol-agnostic, AI-powered yield routing layer for DeFi. Users deposit USDC, pick a risk level, and the protocol routes capital to the best risk-adjusted yield across multiple strategies — governed by on-chain guardrails and managed by an AI-enhanced keeper bot.
+
+**Endgame:** Route capital across any yield source, any protocol, any chain. Today: Marginfi, Kamino, Lulo on Solana. Tomorrow: Mango, Hyperliquid, cross-chain.
+
+### Related Repositories
+
+| Repo | Purpose | Tech Stack |
+|------|---------|------------|
+| `nanuqfi/nanuqfi` | **Core monorepo** — SDK packages + Anchor program | TypeScript, Rust/Anchor, pnpm + Turborepo |
+| `nanuqfi/nanuqfi-keeper` | **AI Keeper** — strategy bot with algorithm engine + Claude AI | TypeScript, Anthropic SDK |
+| `nanuqfi/nanuqfi-app` | **Frontend** — marketing + dashboard + strategy docs (consolidated) | Next.js 16, Tailwind 4, React 19, Playwright E2E |
+| `nanuqfi/nanuqfi-web` | **Marketing site** — public landing page (static export) | Next.js 16 (static), React 19, Tailwind 4 |
+
+**Organization mission:** Build the yield routing layer for DeFi — transparent, trustless, AI-enhanced.
+
+## Cross-Repo Standards
+
+### Coding standards
+- 2-space indentation (TypeScript), standard Rust formatting (Anchor)
+- TypeScript strict mode everywhere
+- One commit per feature/fix, never batch. Conventional commits (`feat:`, `fix:`, `chore:`).
+
+### Testing
+- TDD: write tests BEFORE implementation
+- Tests must NEVER hang — explicit timeouts (5s unit, 30s integration)
+- Every async test has proper setup/teardown (AbortController, close connections)
+- Unit tests offline (mock mode), integration tests on devnet
+- Coverage target: 80%+ (90%+ for keeper and allocator)
+
+### AI Keeper hardening
+- ALWAYS consider failure modes on every keeper change
+- Before claiming any keeper task complete, run through: AI layer failures, algorithm engine failures, Marginfi/Kamino/Lulo/Solana failures, process failures, economic edge cases, cascading failures
+
+### UI standards
+- Custom components ONLY — zero off-the-shelf UI libraries
+- Brand guidelines (`nanuqfi-app/docs/brand-guidelines.md`) as source of truth
+- Dark mode default
+
+### Quality gate
+- Don't ship Phase N+1 until Phase N is bulletproof
+- Phases are about build order and quality, not scope limits
+
+## Repository Index
+
+### 1. nanuqfi/nanuqfi (Core Monorepo) — **YOU ARE HERE**
+
+**Purpose:** Protocol-agnostic SDK (`@nanuqfi/core`, `@nanuqfi/backend-marginfi`, `@nanuqfi/backend-kamino`, `@nanuqfi/backend-lulo`) + on-chain allocator program
+**Tech Stack:** TypeScript, Rust/Anchor 0.30.1, pnpm + Turborepo, Vitest
+
+**Key Commands:**
+```bash
+pnpm install                    # install deps
+pnpm turbo build                # build all packages
+pnpm turbo test                 # run all unit tests
+anchor build                    # build Anchor program
+anchor test                     # run Anchor integration tests
+```
+
+**Package Structure:**
+```
+packages/
+  core/              → @nanuqfi/core (zero-dep interfaces, registry, router, strategy)
+  backend-marginfi/  → @nanuqfi/backend-marginfi (Marginfi lending — real SDK integration)
+  backend-kamino/    → @nanuqfi/backend-kamino (Kamino USDC lending — zero-dep REST API)
+  backend-lulo/      → @nanuqfi/backend-lulo (Lulo aggregator — routes across Kamino/MarginFi/Jupiter)
+  backtest/          → @nanuqfi/backtest (historical simulation engine — CAGR, Sharpe, Sortino, drawdown)
+programs/
+  allocator/         → Anchor program (27 instructions, on-chain guardrails + protocol whitelist + events + account close)
+  nanuqfi-adaptor/   → Ranger Earn adaptor (3 instructions: initialize, deposit, withdraw)
+  mock-ranger-vault/ → Mock Ranger vault for E2E testing (3 instructions, devnet-only)
+scripts/
+  setup-devnet.ts    → Initialize allocator accounts on devnet
+  e2e-gate.ts        → 10-step pre-mainnet E2E test
+  fix-treasury-usdc.ts → Fix treasury USDC mint mismatch (B19 fix)
+  test-phase-b.ts    → Phase B extended on-chain tests (B17-B22)
+```
+
+**Key Files:**
+- `packages/core/src/interfaces.ts` — YieldBackend, BackendCapabilities
+- `packages/core/src/router.ts` — YieldRouter with circuit breaker
+- `packages/core/src/strategy.ts` — BaseVaultStrategy
+- `programs/allocator/src/lib.rs` — All 27 instructions (alloc/recall + whitelist + close + events)
+- `programs/nanuqfi-adaptor/src/lib.rs` — Ranger Earn adaptor (3 instructions + 6 unit tests)
+- `programs/mock-ranger-vault/src/lib.rs` — Mock Ranger vault for devnet CPI testing
+- `programs/allocator/src/state.rs` — Account structs with version fields (Allocator, RiskVault, UserPosition, etc.)
+- `programs/allocator/src/events.rs` — 9 event structs (Deposit, Withdraw, Rebalance, Allocation, etc.)
+- `programs/allocator/src/errors.rs` — Error codes including ArithmeticUnderflow, ProtocolNotWhitelisted, etc.
+
+**Program IDs:**
+- Allocator: `2QtJ5kmxLuW2jYCFpJMtzZ7PCnKdoMwkeueYoDUi5z5P`
+- Ranger Adaptor: `HsNnmuB18pA2U24K4Stc1yan67Cx96gmvGRqBUqRFWwY`
+- Mock Ranger Vault: `FCW6LsSvGAv3UdLixCkm4vygifxR1sVBonuserqFe9Fm` (devnet test-only)
+
+### 2. nanuqfi/nanuqfi-keeper
+
+**Purpose:** AI-powered keeper bot — algorithm engine + Claude AI reasoning + health monitoring + on-chain rebalance + Telegram alerts
+**Tech Stack:** TypeScript, Anthropic SDK, Vitest
+
+**Key Commands:**
+```bash
+pnpm test                       # run all 322 tests
+pnpm build                      # compile TypeScript
+pnpm dev                        # run with tsx (dev mode)
+docker build -t nanuqfi-keeper . # build Docker image
+```
+
+### 3. nanuqfi/nanuqfi-app (Consolidated Frontend)
+
+**Purpose:** Marketing homepage + yield dashboard + vault management + AI activity log + strategy documentation
+**Tech Stack:** Next.js 16 (App Router), React 19, Tailwind 4, Vitest
+**Design System:** Pendle glassmorphism + Ethena data UX hybrid
+
+**Key Commands:**
+```bash
+pnpm dev                        # local dev server
+pnpm build                      # production build
+pnpm test                       # 141 unit tests (Vitest + jsdom)
+pnpm test:e2e                   # 24 Playwright E2E tests
+pnpm lint                       # ESLint
+```
+
+**Routes:** `/` (marketing), `/strategy` (hackathon docs), `/app` (dashboard), `/app/vaults` (explorer), `/app/vaults/[riskLevel]` (detail + deposit), `/app/activity` (AI decisions)
+
+## Current Focus
+
+See [ROADMAP.md](ROADMAP.md) for detailed tracking.
+
+**Hackathon:** Ranger Build-A-Bear — submitted 2026-04-12
+**Domain:** nanuqfi.com (apex, marketing + app, Vercel) + www.nanuqfi.com (308 → apex) + app.nanuqfi.com (308 → nanuqfi.com/app, path preserved) + keeper.nanuqfi.com (API, VPS)
+**Phase:** All phases complete. UI revamped (Pendle + Ethena), transactions wired, strategy docs live. Frontend migrated to Vercel 2026-05-26 (keeper stays on VPS).
+**Tests:** 847 total — 352 core monorepo (212 TS + 132 Rust + 8 integration) + 322 keeper + 169 frontend (145 unit + 24 E2E)
+**Programs:** 33 instructions total — 27 allocator + 3 adaptor + 3 mock vault
+**On-chain TVL:** ~260 USDC (moderate: 210, aggressive: 50) — needs redeploy after hardening
+**Submission:** Strategy docs at nanuqfi.com/strategy, demo video at nanuqfi.com/cdn/videos/demo.mp4 (5:46, 13.5MB).
+
+---
+
+# NanuqFi Core Repository
+
+> The sections below are specific to this repository (the SDK + Anchor program monorepo).
+
+## Architecture
+
+The core monorepo publishes four npm packages and one Anchor program:
+
+### @nanuqfi/core (zero external dependencies)
+- `YieldBackend` / `BackendCapabilities` — interfaces every yield source implements
+- `YieldBackendRegistry` — stores and queries backends by capability
+- `YieldRouter` — ranks backends by risk-adjusted yield, with circuit breaker + logger
+- `BaseVaultStrategy` — abstract class with weight/guardrail validation
+- `MockYieldBackend` — deterministic mock for testing
+- `CircuitBreaker` — CLOSED → OPEN → HALF_OPEN state machine
+- `fetchWithRetry` — HTTP retry with exponential backoff + AbortController timeout
+- `Logger` / `consoleLogger` / `noopLogger` — structured JSON logging interface
+- `TtlCache` — injectable cache with TTL + stale-while-revalidate support
+
+### @nanuqfi/backend-marginfi (real Marginfi SDK integration)
+- `MarginfiLendingBackend` — USDC lending with mock + real mode (live mainnet rates via MarginfiClient)
+- `createReadOnlyMarginfiClient` — connection factory for mainnet bank data reads
+- `fetchLendingRate` / `fetchBankMetrics` — cached on-chain rate fetching (60s TTL)
+- `fetchHistoricalRates` — DeFi Llama historical APY timeseries for backtesting
+- Implements same `YieldBackend` interface — zero coupling to any specific protocol
+
+### @nanuqfi/backend-kamino (zero-dep REST API integration)
+- `KaminoLendingBackend` — USDC lending with mock + real mode (live mainnet rates via Kamino REST API)
+- `fetchUsdcReserveMetrics` — live reserve data (APY, TVL, utilization)
+- `fetchHistoricalMetrics` — 21,000+ daily data points since Oct 2023 for backtesting
+- Zero SDK dependency — pure HTTP via `api.kamino.finance`
+- Implements same `YieldBackend` interface — zero coupling to any specific protocol
+
+### @nanuqfi/backend-lulo (Lulo lending aggregator)
+- `LuloLendingBackend` — USDC via Lulo aggregator (mock + real mode, live mainnet rates)
+- `fetchLuloRates` — current + 24h APY rates from `api.lulo.fi/v1/rates.getRates` (converts % → decimal)
+- `fetchLuloPoolData` — pool TVL, utilization, and per-pool APYs from `api.lulo.fi/v1/pool.getPools`
+- Lulo routes across Kamino, MarginFi, Jupiter for best yield — "yield aggregator on aggregator"
+- Requires `x-api-key` header for all requests (env: `LULO_API_KEY`)
+
+### @nanuqfi/backtest (historical simulation engine)
+- `runBacktest` — day-by-day scoring simulation across Kamino/Marginfi/Lulo
+- `fetchHistoricalData` — 21K+ Kamino historical data points with protocol estimates
+- `computeMetrics` — CAGR, Sharpe ratio, Sortino ratio, max drawdown, volatility
+- Proves router outperforms any single protocol over 2.5 years of data
+
+### Allocator Program (Anchor/Rust)
+27 instructions: initialize_allocator, initialize_risk_vault, initialize_treasury, deposit, request_withdraw, withdraw, rebalance, emergency_halt, resume, update_keeper_authority, update_guardrails, acquire_lease, heartbeat, withdraw_treasury, allocate_to_protocol, recall_from_protocol, update_deposit_cap, update_treasury_usdc, admin_reset_vault (devnet), admin_set_tvl (devnet), admin_set_redemption_period, admin_set_rebalance_counter (devnet), admin_set_max_single_deposit, add_whitelisted_protocol, remove_whitelisted_protocol, close_user_position, close_rebalance_record
+
+**Trust model:** Users trust the on-chain program (auditable), not the keeper. Keeper proposes → algorithm validates → program enforces.
+
+## Design Patterns (from SIP Protocol)
+
+1. Interface-first + Registry + SmartRouter with circuit breaker
+2. Capability descriptors, not conditionals
+3. Risk levels as first-class enum (`conservative | moderate | aggressive`)
+4. Mock implementations for every interface
+5. Abstract base class for shared strategy logic
+6. Metadata escape hatch (`Record<string, unknown>`)


### PR DESCRIPTION
Adopts the host-neutral satellite model: `AGENTS.md` holds project-specific context; persona and dev standards remain in the global hub (`~/.claude/CLAUDE.md` / `~/.pi/agent/AGENTS.md`).